### PR TITLE
PROTON-1409 Exposing delivery length

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/Delivery.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/Delivery.java
@@ -54,6 +54,12 @@ public interface Delivery extends Extendable
      */
     public void settle();
 
+    /** Returns the number of available bytes to be read at this delivery.
+     *
+     *  The delivery might still be incomplete at the time this method is called,
+     *  so this will only return the number of bytes it already knows.*/
+    int getReadableBytes();
+
     /**
      * Returns whether this delivery has been settled.
      *

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/DeliveryImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/DeliveryImpl.java
@@ -366,9 +366,10 @@ public class DeliveryImpl implements Delivery
         return _offset;
     }
 
-    int getDataLength()
+    @Override
+    public int getReadableBytes()
     {
-        return _dataSize;  //TODO - Implement.
+        return _dataSize;
     }
 
     void setData(byte[] data)

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
@@ -526,7 +526,7 @@ public class TransportImpl extends EndpointImpl
         boolean wasDone = delivery.isDone();
 
         if(!delivery.isDone() &&
-           (delivery.getDataLength() > 0 || delivery != snd.current()) &&
+           (delivery.getReadableBytes() > 0 || delivery != snd.current()) &&
            tpSession.hasOutgoingCredit() && tpLink.hasCredit() &&
            tpSession.isLocalChannelSet() &&
            tpLink.getLocalHandle() != null && !_frameWriter.isFull())
@@ -578,7 +578,7 @@ public class TransportImpl extends EndpointImpl
 
             ByteBuffer payload = delivery.getData() ==  null ? null :
                 ByteBuffer.wrap(delivery.getData(), delivery.getDataOffset(),
-                                delivery.getDataLength());
+                                delivery.getReadableBytes());
 
             writeFrame(tpSession.getLocalChannel(), transfer, payload,
                        new PartialTransfer(transfer));
@@ -605,7 +605,7 @@ public class TransportImpl extends EndpointImpl
             }
             else
             {
-                int delta = delivery.getDataLength() - payload.remaining();
+                int delta = delivery.getReadableBytes() - payload.remaining();
                 delivery.setDataOffset(delivery.getDataOffset() + delta);
                 delivery.setDataLength(payload.remaining());
                 session.incrementOutgoingBytes(-delta);

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportSession.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportSession.java
@@ -299,7 +299,7 @@ class TransportSession
         // TODO - should this be a copy?
         if(payload != null)
         {
-            if(delivery.getDataLength() == 0)
+            if(delivery.getReadableBytes() == 0)
             {
                 delivery.setData(payload.getArray());
                 delivery.setDataLength(payload.getLength());
@@ -307,9 +307,9 @@ class TransportSession
             }
             else
             {
-                byte[] data = new byte[delivery.getDataLength() + payload.getLength()];
-                System.arraycopy(delivery.getData(), delivery.getDataOffset(), data, 0, delivery.getDataLength());
-                System.arraycopy(payload.getArray(), payload.getArrayOffset(), data, delivery.getDataLength(), payload.getLength());
+                byte[] data = new byte[delivery.getReadableBytes() + payload.getLength()];
+                System.arraycopy(delivery.getData(), delivery.getDataOffset(), data, 0, delivery.getReadableBytes());
+                System.arraycopy(payload.getArray(), payload.getArrayOffset(), data, delivery.getReadableBytes(), payload.getLength());
                 delivery.setData(data);
                 delivery.setDataOffset(0);
                 delivery.setDataLength(data.length);

--- a/proton-j/src/test/java/org/apache/qpid/proton/engine/impl/DeferredSettlementTest.java
+++ b/proton-j/src/test/java/org/apache/qpid/proton/engine/impl/DeferredSettlementTest.java
@@ -413,10 +413,13 @@ public class DeferredSettlementTest extends EngineTestBase
         assertFalse(delivery.isPartial());
         assertTrue(delivery.isReadable());
 
-        byte[] received = new byte[BUFFER_SIZE];
-        int len = clientReceiver.recv(received, 0, BUFFER_SIZE);
+        /** Instead of creating a big buffer, we will create a buffer with the exact
+         *  number of available bytes at the delivery now */
+        int size = delivery.getReadableBytes();
+        byte[] received = new byte[delivery.getReadableBytes()];
+        int len = clientReceiver.recv(received, 0, size);
 
-        assertTrue("given array was too small", len < BUFFER_SIZE);
+        assertEquals("Should have received " + len + " bytes", size, len);
 
         Message m = Proton.message();
         m.decode(received, 0, len);


### PR DESCRIPTION
This is to expose the delivery length to allow creating the buffer with the required bytes only

https://issues.apache.org/jira/browse/PROTON-1409