### PR TITLE
PROTON-1486: Expose SaslOutcome additional-data to users of the API

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/Sasl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/Sasl.java
@@ -119,7 +119,7 @@ public interface Sasl
     int pending();
 
     /**
-     * Read challenge/response data sent from the peer.
+     * Read challenge/response/additional data sent from the peer.
      *
      * Use pending to determine the size of the data.
      *
@@ -131,7 +131,7 @@ public interface Sasl
     int recv(byte[] bytes, int offset, int size);
 
     /**
-     * Send challenge or response data to the peer.
+     * Send challenge/response/additional data to the peer.
      *
      * @param bytes The challenge/response data.
      * @param offset the point within the array at which the data starts at

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/SaslImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/SaslImpl.java
@@ -159,7 +159,12 @@ public class SaslImpl implements Sasl, SaslFrameBody.SaslFrameBodyHandler<Void>,
                 org.apache.qpid.proton.amqp.security.SaslOutcome outcome =
                         new org.apache.qpid.proton.amqp.security.SaslOutcome();
                 outcome.setCode(SaslCode.values()[_outcome.getCode()]);
+                if (_outcome == PN_SASL_OK)
+                {
+                    outcome.setAdditionalData(getChallengeResponse());
+                }
                 writeFrame(outcome);
+                setChallengeResponse(null);
             }
         }
         else if(_role == Role.CLIENT)
@@ -394,6 +399,7 @@ public class SaslImpl implements Sasl, SaslFrameBody.SaslFrameBodyHandler<Void>,
         checkRole(Role.CLIENT);
         for(SaslOutcome outcome : SaslOutcome.values())
         {
+            setPending(saslOutcome.getAdditionalData()  == null ? null : saslOutcome.getAdditionalData().asByteBuffer());
             if(outcome.getCode() == saslOutcome.getCode().ordinal())
             {
                 _outcome = outcome;


### PR DESCRIPTION
Based on original work by rgodfrey <rgodfrey@apache.org>

Having reviewed the existing API, it seemed reusing the existing send/recv interface for the sending/receiving of additional-data was the most fitting.    Supporting test cases added.