### PR TITLE
PROTON-1606: Added ability to make SASL communication optional

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/Proton.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/Proton.java
@@ -106,4 +106,19 @@ public final class Proton
         }
         return reactor;
     }
+
+
+    public static Reactor reactor(ReactorOptions options) throws IOException
+    {
+        return Reactor.Factory.create(options);
+    }
+
+    public static Reactor reactor(ReactorOptions options, Handler... handlers) throws IOException
+    {
+        Reactor reactor = Reactor.Factory.create(options);
+        for (Handler handler : handlers) {
+            reactor.getHandler().add(handler);
+        }
+        return reactor;
+    }
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/ReactorOptions.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/ReactorOptions.java
@@ -1,0 +1,52 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.qpid.proton;
+
+public class ReactorOptions {
+    private boolean isSaslCreatedByDefault;
+
+    public ReactorOptions() {
+        //Default case creates SASL
+        isSaslCreatedByDefault = true;
+    }
+
+    /**
+     * The default handlers will not create the SASL layer by default. They can still be created by user later
+     */
+    public void disableSaslByDefault() {
+        this.isSaslCreatedByDefault = false;
+    }
+
+    /**
+     * The default handlers will create the SASL layer by default.
+     */
+    public void enableSaslByDefault() {
+        this.isSaslCreatedByDefault = true;
+    }
+
+    /**
+     * Returns If the SASL is created by default
+     * @return True if SASL will be created by default. False otherwise
+     */
+    public boolean isSaslCreatedByDefault() {
+        return this.isSaslCreatedByDefault;
+    }
+}

--- a/proton-j/src/main/java/org/apache/qpid/proton/reactor/Reactor.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/reactor/Reactor.java
@@ -24,6 +24,7 @@ package org.apache.qpid.proton.reactor;
 import java.io.IOException;
 import java.util.Set;
 
+import org.apache.qpid.proton.ReactorOptions;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Collector;
 import org.apache.qpid.proton.engine.Connection;
@@ -50,6 +51,10 @@ public interface Reactor {
     {
         public static Reactor create() throws IOException {
             return new ReactorImpl();
+        }
+
+        public static Reactor create(ReactorOptions options) throws IOException {
+            return new ReactorImpl(options);
         }
     }
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/reactor/impl/IOHandler.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/reactor/impl/IOHandler.java
@@ -29,6 +29,7 @@ import java.nio.channels.SocketChannel;
 import java.util.Iterator;
 
 import org.apache.qpid.proton.Proton;
+import org.apache.qpid.proton.ReactorOptions;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.engine.BaseHandler;
@@ -48,6 +49,16 @@ import org.apache.qpid.proton.reactor.impl.AcceptorImpl;
 
 @SuppressWarnings("deprecation")
 public class IOHandler extends BaseHandler {
+
+    private ReactorOptions options;
+
+    public IOHandler() {
+        this.options = new ReactorOptions();
+    }
+
+    public IOHandler(ReactorOptions options) {
+        this.options = options;
+    }
 
     // pni_handle_quiesced from connection.c
     private void handleQuiesced(Reactor reactor, Selector selector) throws IOException {
@@ -101,9 +112,13 @@ public class IOHandler extends BaseHandler {
             // setHostname set by application - use it.
         }
         Transport transport = Proton.transport();
-        Sasl sasl = transport.sasl();
-        sasl.client();
-        sasl.setMechanisms("ANONYMOUS");
+
+        if (this.options.isSaslCreatedByDefault()) {
+            Sasl sasl = transport.sasl();
+            sasl.client();
+            sasl.setMechanisms("ANONYMOUS");
+        }
+
         transport.bind(connection);
     }
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/reactor/impl/ReactorImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/reactor/impl/ReactorImpl.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.qpid.proton.Proton;
+import org.apache.qpid.proton.ReactorOptions;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Collector;
 import org.apache.qpid.proton.engine.Connection;
@@ -98,8 +99,17 @@ public class ReactorImpl implements Reactor, Extendable {
         attachments = new RecordImpl();
     }
 
+    protected ReactorImpl(IO io, ReactorOptions options) throws IOException {
+        this(io);
+        global = new IOHandler(options);
+    }
+
     public ReactorImpl() throws IOException {
-        this(new IOImpl());
+        this(new IOImpl(), new ReactorOptions());
+    }
+
+    public ReactorImpl(ReactorOptions options) throws IOException {
+        this(new IOImpl(), options);
     }
 
     @Override


### PR DESCRIPTION
Previously, the IOhandler created to be the global handler automatically created the SASL layer whether a user of the library wanted it or not. This commit exposes an option when creating the reactor to disable creating the SASL layer at all.

https://issues.apache.org/jira/browse/PROTON-1606