### PR TITLE
PROTON-1690 JMH Benchmarks for baseline performance of Message encoding/decoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,13 +180,14 @@
   </ciManagement>
 
   <profiles>
-    <!-- Override the apache-release profile from the parent. Skip creating
-         a source release here, we have a release module that does it.  -->
+    <!-- Override the apache-release profile from the parent pom -->
     <profile>
       <id>apache-release</id>
       <build>
         <plugins>
           <plugin>
+            <!-- Skip creating a source release here, as we
+                 have a release module that does it.  -->
             <artifactId>maven-assembly-plugin</artifactId>
             <executions>
               <execution>
@@ -199,6 +200,19 @@
           </plugin>
         </plugins>
       </build>
+      <!-- Enable the optional performance-jmh module too, so that it gets
+           the version updated by the maven-release-plugin during release.
+           The module is configured not to deploy anything. -->
+      <modules>
+        <module>tests/performance-jmh</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>performance-jmh</id>
+      <modules>
+        <module>tests/performance-jmh</module>
+      </modules>
     </profile>
 
     <profile>

--- a/tests/performance-jmh/README.md
+++ b/tests/performance-jmh/README.md
@@ -1,0 +1,43 @@
+Proton-J Benchmarks
+-------
+This project contains performance tests designed to stress performance critical parts of the proton engine 
+(eg encoders, decoders).
+
+Building the benchmarks
+-------
+The benchmarks are maven built and involve some code generation for the JMH part. As such it is required that you
+run 'mvn clean install' on changing the code. As the codebase is rather small it is recommended that you run this
+command from the parent folder to avoid missed changes from other packages.
+
+Running the benchmarks: General
+-------
+It is recommended that you consider some basic benchmarking practices before running benchmarks:
+
+ 1. Use a quiet machine with enough CPUs to run the number of threads you mean to run.
+ 2. Set the CPU freq to avoid variance due to turbo boost/heating.
+ 3. Use an OS tool such as taskset to pin the threads in the topology you mean to measure.
+
+Running the JMH Benchmarks
+-----
+To run all JMH benchmarks:
+
+    java -jar target/proton-j-performance-jmh.jar -f <number-of-forks> -wi <number-of-warmup-iterations> -i <number-of-iterations>
+To list available benchmarks:
+
+    java -jar target/proton-j-performance-jmh.jar -l
+Some JMH help:
+
+    java -jar target/proton-j-performance-jmh.jar -h
+    
+Example
+-----
+To run a benchmark on the String decoding while saving the results in json format:
+
+    java -jar target/proton-j-performance-jmh.jar StringsBenchmark.decode* -f 1 -wi 5 -i 5 -rf json -rff strings_decode_before.json -gc true
+    
+After changed something in the String decode path and compiled the whole project, can be taken 
+another snapshot of the current state of performances for the same case:
+
+    java -jar target/proton-j-performance-jmh.jar StringsBenchmark.decode* -f 1 -wi 5 -i 5 -rf json -rff strings_decode_after.json -gc true   
+
+then it is possible to use many graphical tools to compare the results: one is [JMH Visualizer](http://jmh.morethan.io/). 

--- a/tests/performance-jmh/pom.xml
+++ b/tests/performance-jmh/pom.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <groupId>org.apache.qpid</groupId>
+        <artifactId>proton-j-parent</artifactId>
+        <version>0.24.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>proton-j-performance-jmh</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Proton-J JMH Performance Tests</name>
+
+    <properties>
+        <jmh-version>1.19</jmh-version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.qpid</groupId>
+            <artifactId>proton-j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh-version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>proton-j-performance-jmh</finalName>
+                            <transformers>
+                                <transformer
+                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Don't deploy artifacts for this module. It has non-permissive
+                 dependencies and is only optionally used for local testing. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>perform-release-checks</id>
+            <activation>
+                <property>
+                    <name>perform-release-checks</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-release-version</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireReleaseVersion>
+                                            <message>Module still has a SNAPSHOT version! Ensure release is prepared
+                                                using "mvn release-prepare -Papache-release"
+                                            </message>
+                                        </requireReleaseVersion>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/ApplicationPropertiesBenchmark.java
+++ b/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/ApplicationPropertiesBenchmark.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton.message;
+
+import org.apache.qpid.proton.amqp.UnsignedByte;
+import org.apache.qpid.proton.amqp.UnsignedInteger;
+import org.apache.qpid.proton.amqp.UnsignedShort;
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+
+public class ApplicationPropertiesBenchmark extends MessageBenchmark
+{
+
+    private ApplicationProperties properties;
+
+    @Setup
+    public void init()
+    {
+        super.init();
+        initApplicationProperties();
+        encode();
+    }
+
+    private void initApplicationProperties()
+    {
+        properties = new ApplicationProperties(new HashMap<String, Object>());
+        properties.getValue().put("test1", UnsignedByte.valueOf((byte) 128));
+        properties.getValue().put("test2", UnsignedShort.valueOf((short) 128));
+        properties.getValue().put("test3", UnsignedInteger.valueOf((byte) 128));
+    }
+
+    @Benchmark
+    @Override
+    public ByteBuffer encode()
+    {
+        return encodeObj(properties);
+    }
+
+    @Benchmark
+    @Override
+    public Object decode()
+    {
+        return super.decode();
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        runBenchmark(ApplicationPropertiesBenchmark.class);
+    }
+}

--- a/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/DataBenchmark.java
+++ b/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/DataBenchmark.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton.message;
+
+import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.nio.ByteBuffer;
+
+public class DataBenchmark extends MessageBenchmark
+{
+
+    private Blackhole blackhole;
+    private Data data1;
+    private Data data2;
+    private Data data3;
+
+    @Setup
+    public void init(Blackhole blackhole)
+    {
+        this.blackhole = blackhole;
+        super.init();
+        initData();
+        encode();
+    }
+
+    private void initData()
+    {
+        data1 = new Data(new Binary(new byte[] {1, 2, 3}));
+        data2 = new Data(new Binary(new byte[] {4, 5, 6}));
+        data3 = new Data(new Binary(new byte[] {7, 8, 9}));
+    }
+
+    @Benchmark
+    @Override
+    public ByteBuffer encode()
+    {
+        byteBuf.clear();
+        encoder.writeObject(data1);
+        encoder.writeObject(data2);
+        encoder.writeObject(data3);
+        return byteBuf;
+    }
+
+    @Benchmark
+    @Override
+    public Object decode()
+    {
+        byteBuf.flip();
+        blackhole.consume(decoder.readObject());
+        blackhole.consume(decoder.readObject());
+        blackhole.consume(decoder.readObject());
+        return byteBuf;
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        runBenchmark(DataBenchmark.class);
+    }
+}

--- a/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/DispositionBenchmark.java
+++ b/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/DispositionBenchmark.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton.message;
+
+import org.apache.qpid.proton.amqp.UnsignedInteger;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.transport.Disposition;
+import org.apache.qpid.proton.amqp.transport.Role;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.nio.ByteBuffer;
+
+public class DispositionBenchmark extends MessageBenchmark
+{
+
+    private Disposition disposition;
+
+    @Setup
+    public void init()
+    {
+        super.init();
+        initDisposition();
+        encode();
+    }
+
+    private void initDisposition()
+    {
+        disposition = new Disposition();
+        disposition.setRole(Role.RECEIVER);
+        disposition.setSettled(true);
+        disposition.setState(Accepted.getInstance());
+        disposition.setFirst(UnsignedInteger.valueOf(2));
+        disposition.setLast(UnsignedInteger.valueOf(2));
+    }
+
+    @Benchmark
+    @Override
+    public ByteBuffer encode()
+    {
+        return super.encodeObj(disposition);
+    }
+
+    @Benchmark
+    @Override
+    public Object decode()
+    {
+        return super.decode();
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        runBenchmark(DispositionBenchmark.class);
+    }
+}

--- a/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/FlowBenchmark.java
+++ b/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/FlowBenchmark.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton.message;
+
+import org.apache.qpid.proton.amqp.UnsignedInteger;
+import org.apache.qpid.proton.amqp.transport.Flow;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.nio.ByteBuffer;
+
+public class FlowBenchmark extends MessageBenchmark
+{
+
+    private Flow flow;
+
+    @Setup
+    public void init()
+    {
+        super.init();
+        initFlow();
+        encode();
+    }
+
+    private void initFlow()
+    {
+        flow = new Flow();
+        flow.setNextIncomingId(UnsignedInteger.valueOf(1));
+        flow.setIncomingWindow(UnsignedInteger.valueOf(2047));
+        flow.setNextOutgoingId(UnsignedInteger.valueOf(1));
+        flow.setOutgoingWindow(UnsignedInteger.MAX_VALUE);
+        flow.setHandle(UnsignedInteger.ZERO);
+        flow.setDeliveryCount(UnsignedInteger.valueOf(10));
+        flow.setLinkCredit(UnsignedInteger.valueOf(1000));
+    }
+
+    @Benchmark
+    @Override
+    public ByteBuffer encode()
+    {
+        return encodeObj(flow);
+    }
+
+    @Benchmark
+    @Override
+    public Object decode()
+    {
+        return super.decode();
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        runBenchmark(FlowBenchmark.class);
+    }
+}

--- a/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/HeaderBenchmark.java
+++ b/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/HeaderBenchmark.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton.message;
+
+import org.apache.qpid.proton.amqp.messaging.Header;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.nio.ByteBuffer;
+
+public class HeaderBenchmark extends MessageBenchmark
+{
+
+    private Header header;
+
+    @Setup
+    public void init()
+    {
+        super.init();
+        initHeader();
+        encode();
+    }
+
+    private void initHeader()
+    {
+        header = new Header();
+        header.setDurable(true);
+        header.setFirstAcquirer(true);
+    }
+
+    @Benchmark
+    @Override
+    public Object decode()
+    {
+        return super.decode();
+    }
+
+    @Benchmark
+    @Override
+    public ByteBuffer encode()
+    {
+        return encodeObj(header);
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        runBenchmark(HeaderBenchmark.class);
+    }
+}

--- a/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/ListOfIntsBenchmark.java
+++ b/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/ListOfIntsBenchmark.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton.message;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ListOfIntsBenchmark extends MessageBenchmark
+{
+
+    private static final int LIST_SIZE = 10;
+    private ArrayList<Object> listOfInts;
+
+    @Setup
+    public void init()
+    {
+        super.init();
+        initListOfInts();
+        encode();
+    }
+
+    private void initListOfInts()
+    {
+        this.listOfInts = new ArrayList<>(LIST_SIZE);
+        for (int i = 0; i < LIST_SIZE; i++)
+        {
+            listOfInts.add(i);
+        }
+    }
+
+    @Benchmark
+    @Override
+    public ByteBuffer encode()
+    {
+        byteBuf.clear();
+        encoder.writeList(listOfInts);
+        return byteBuf;
+    }
+
+    @Benchmark
+    @Override
+    public List decode()
+    {
+        byteBuf.flip();
+        return decoder.readList();
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        runBenchmark(ListOfIntsBenchmark.class);
+    }
+
+}

--- a/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/MessageAnnotationsBenchmark.java
+++ b/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/MessageAnnotationsBenchmark.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton.message;
+
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.UnsignedByte;
+import org.apache.qpid.proton.amqp.UnsignedInteger;
+import org.apache.qpid.proton.amqp.UnsignedShort;
+import org.apache.qpid.proton.amqp.messaging.MessageAnnotations;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+
+public class MessageAnnotationsBenchmark extends MessageBenchmark
+{
+
+    private MessageAnnotations annotations;
+
+    @Setup
+    public void init()
+    {
+        super.init();
+        initMessageAnnotations();
+        encode();
+    }
+
+    private void initMessageAnnotations()
+    {
+        annotations = new MessageAnnotations(new HashMap<Symbol, Object>());
+        annotations.getValue().put(Symbol.valueOf("test1"), UnsignedByte.valueOf((byte) 128));
+        annotations.getValue().put(Symbol.valueOf("test2"), UnsignedShort.valueOf((short) 128));
+        annotations.getValue().put(Symbol.valueOf("test3"), UnsignedInteger.valueOf((byte) 128));
+    }
+
+    @Benchmark
+    @Override
+    public ByteBuffer encode()
+    {
+        return super.encodeObj(annotations);
+    }
+
+    @Benchmark
+    @Override
+    public Object decode()
+    {
+        return super.decode();
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        runBenchmark(MessageAnnotationsBenchmark.class);
+    }
+}

--- a/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/MessageBenchmark.java
+++ b/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/MessageBenchmark.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton.message;
+
+import org.apache.qpid.proton.codec.AMQPDefinedTypes;
+import org.apache.qpid.proton.codec.DecoderImpl;
+import org.apache.qpid.proton.codec.EncoderImpl;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public abstract class MessageBenchmark
+{
+
+    public static final int DEFAULT_BUFFER_SIZE = 8192;
+    protected ByteBuffer byteBuf;
+    protected DecoderImpl decoder;
+    protected EncoderImpl encoder;
+
+    /**
+     * It could be overridden to allow encoding/decoding buffer to be sized differently from  {@link #DEFAULT_BUFFER_SIZE}
+     */
+    protected int bufferSize()
+    {
+        return DEFAULT_BUFFER_SIZE;
+    }
+
+    public void init()
+    {
+        byteBuf = ByteBuffer.allocate(bufferSize());
+        this.decoder = new DecoderImpl();
+        this.encoder = new EncoderImpl(decoder);
+        AMQPDefinedTypes.registerAllTypes(decoder, encoder);
+        //initialize encoders
+        encoder.setByteBuffer(byteBuf);
+        decoder.setByteBuffer(byteBuf);
+    }
+
+    public abstract ByteBuffer encode();
+
+    protected final ByteBuffer encodeObj(Object obj)
+    {
+        byteBuf.clear();
+        encoder.writeObject(obj);
+        return byteBuf;
+    }
+
+    /**
+     * By default it performs a {@link DecoderImpl#readObject()}.
+     */
+    protected Object decode()
+    {
+        byteBuf.flip();
+        return decoder.readObject();
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        runBenchmark(MessageBenchmark.class);
+    }
+
+    public static void runBenchmark(Class<?> benchmarkClass) throws RunnerException
+    {
+        final Options opt = new OptionsBuilder()
+            .include(benchmarkClass.getSimpleName())
+            .addProfiler(GCProfiler.class)
+            .shouldDoGC(true)
+            .warmupIterations(5)
+            .measurementIterations(5)
+            .forks(1)
+            .build();
+        new Runner(opt).run();
+    }
+
+}

--- a/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/PropertiesBenchmark.java
+++ b/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/PropertiesBenchmark.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton.message;
+
+import org.apache.qpid.proton.amqp.messaging.Properties;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.nio.ByteBuffer;
+import java.util.Date;
+
+public class PropertiesBenchmark extends MessageBenchmark
+{
+
+    private Properties properties;
+
+    @Setup
+    public void init()
+    {
+        super.init();
+        initProperties();
+        encode();
+    }
+
+    private void initProperties()
+    {
+        properties = new Properties();
+        properties.setTo("queue:1");
+        properties.setMessageId("ID:Message:1");
+        properties.setCreationTime(new Date(System.currentTimeMillis()));
+    }
+
+    @Benchmark
+    @Override
+    public ByteBuffer encode()
+    {
+        return encodeObj(properties);
+    }
+
+    @Benchmark
+    @Override
+    public Object decode()
+    {
+        return super.decode();
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        runBenchmark(PropertiesBenchmark.class);
+    }
+}

--- a/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/StringsBenchmark.java
+++ b/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/StringsBenchmark.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton.message;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.nio.ByteBuffer;
+
+public class StringsBenchmark extends MessageBenchmark
+{
+
+    private Blackhole blackhole;
+    private String string1;
+    private String string2;
+    private String string3;
+
+    @Setup
+    public void init(Blackhole blackhole)
+    {
+        this.blackhole = blackhole;
+        super.init();
+        initStrings();
+        encode();
+    }
+
+    private void initStrings()
+    {
+        string1 = new String("String-1");
+        string2 = new String("String-2");
+        string3 = new String("String-3");
+    }
+
+    @Benchmark
+    @Override
+    public ByteBuffer encode()
+    {
+        byteBuf.clear();
+        encoder.writeString(string1);
+        encoder.writeString(string2);
+        encoder.writeString(string3);
+        return byteBuf;
+    }
+
+    @Benchmark
+    @Override
+    public Object decode()
+    {
+        byteBuf.flip();
+        blackhole.consume(decoder.readString());
+        blackhole.consume(decoder.readString());
+        blackhole.consume(decoder.readString());
+        return byteBuf;
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        runBenchmark(StringsBenchmark.class);
+    }
+}

--- a/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/SymbolsBenchmark.java
+++ b/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/SymbolsBenchmark.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton.message;
+
+import org.apache.qpid.proton.amqp.Symbol;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.nio.ByteBuffer;
+
+public class SymbolsBenchmark extends MessageBenchmark
+{
+
+    private Symbol symbol1;
+    private Symbol symbol2;
+    private Symbol symbol3;
+    private Blackhole blackhole;
+
+    @Setup
+    public void init(Blackhole blackhole)
+    {
+        this.blackhole = blackhole;
+        super.init();
+        initSymbols();
+        encode();
+    }
+
+    private void initSymbols()
+    {
+        symbol1 = Symbol.valueOf("Symbol-1");
+        symbol2 = Symbol.valueOf("Symbol-2");
+        symbol3 = Symbol.valueOf("Symbol-3");
+    }
+
+    @Benchmark
+    @Override
+    public ByteBuffer encode()
+    {
+        byteBuf.clear();
+        encoder.writeSymbol(symbol1);
+        encoder.writeSymbol(symbol2);
+        encoder.writeSymbol(symbol3);
+        return byteBuf;
+    }
+
+    @Benchmark
+    @Override
+    public Object decode()
+    {
+        byteBuf.flip();
+        //these ones are necessary to avoid JVM erase the decode processing/symbol allocations
+        blackhole.consume(decoder.readSymbol());
+        blackhole.consume(decoder.readSymbol());
+        blackhole.consume(decoder.readSymbol());
+        return byteBuf;
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        runBenchmark(SymbolsBenchmark.class);
+    }
+}

--- a/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/TransferBenchmark.java
+++ b/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/TransferBenchmark.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton.message;
+
+import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.UnsignedInteger;
+import org.apache.qpid.proton.amqp.transport.Transfer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.nio.ByteBuffer;
+
+public class TransferBenchmark extends MessageBenchmark
+{
+
+    private Transfer transfer;
+
+    @Setup
+    public void init()
+    {
+        super.init();
+        initTransfer();
+        encode();
+    }
+
+    private void initTransfer()
+    {
+        transfer = new Transfer();
+        transfer.setDeliveryTag(new Binary(new byte[] {1, 2, 3}));
+        transfer.setHandle(UnsignedInteger.valueOf(10));
+        transfer.setMessageFormat(UnsignedInteger.ZERO);
+    }
+
+    @Benchmark
+    @Override
+    public Object decode()
+    {
+        return super.decode();
+    }
+
+    @Benchmark
+    @Override
+    public ByteBuffer encode()
+    {
+        return encodeObj(transfer);
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        runBenchmark(TransferBenchmark.class);
+    }
+}

--- a/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/UUIDBenchmark.java
+++ b/tests/performance-jmh/src/main/java/org/apache/qpid/proton/message/UUIDBenchmark.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.qpid.proton.message;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.runner.RunnerException;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+
+public class UUIDBenchmark extends MessageBenchmark
+{
+
+    private UUID uuid;
+
+    @Setup
+    public void init()
+    {
+        super.init();
+        initUUID();
+        encode();
+    }
+
+    private void initUUID()
+    {
+        this.uuid = UUID.randomUUID();
+    }
+
+    @Benchmark
+    @Override
+    public ByteBuffer encode()
+    {
+        byteBuf.clear();
+        encoder.writeUUID(uuid);
+        return byteBuf;
+    }
+
+    @Benchmark
+    @Override
+    public UUID decode()
+    {
+        byteBuf.flip();
+        return decoder.readUUID();
+    }
+
+    public static void main(String[] args) throws RunnerException
+    {
+        runBenchmark(UUIDBenchmark.class);
+    }
+
+}


### PR DESCRIPTION
It adds a module to perform reliable (and repeatible) benchmarks of a basic Message encoding/decoding with variable encoding length (in bytes).

The benchmark can be run from the IDE (to test immediatly some changes in the dev fork/branch) or as a standalone jar, while its results could be saved in several forms (normal text, CSV, JSON etc).

It is just the base that could contain future benchmarks on other perf sensitivel parts.