### PR TITLE
PROTON-1998: Add SASL protocol trace

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/ProtocolTracer.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/ProtocolTracer.java
@@ -20,6 +20,8 @@
  */
 package org.apache.qpid.proton.engine.impl;
 
+import org.apache.qpid.proton.amqp.security.SaslFrameBody;
+import org.apache.qpid.proton.amqp.transport.FrameBody;
 import org.apache.qpid.proton.framing.TransportFrame;
 
 /**
@@ -27,6 +29,9 @@ import org.apache.qpid.proton.framing.TransportFrame;
  */
 public interface ProtocolTracer
 {
-    public void receivedFrame(TransportFrame transportFrame);
-    public void sentFrame(TransportFrame transportFrame);
+    default void receivedFrame(TransportFrame transportFrame) {}
+    default void sentFrame(TransportFrame transportFrame) {}
+    default void receivedSaslBody(SaslFrameBody saslFrameBody) {};
+    default void sentSaslBody(SaslFrameBody saslFrameBody) {};
+
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/SaslImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/SaslImpl.java
@@ -317,7 +317,14 @@ public class SaslImpl implements Sasl, SaslFrameBody.SaslFrameBodyHandler<Void>,
     @Override
     public void handle(SaslFrameBody frameBody, Binary payload)
     {
+        _transport.log(TransportImpl.INCOMING, frameBody);
         frameBody.invoke(this, payload, null);
+
+        ProtocolTracer tracer = _transport.getProtocolTracer();
+        if( tracer != null )
+        {
+            tracer.receivedSaslBody(frameBody);
+        }
     }
 
     @Override

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
@@ -30,6 +30,7 @@ import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.UnsignedInteger;
 import org.apache.qpid.proton.amqp.UnsignedShort;
+import org.apache.qpid.proton.amqp.security.SaslFrameBody;
 import org.apache.qpid.proton.amqp.transport.Attach;
 import org.apache.qpid.proton.amqp.transport.Begin;
 import org.apache.qpid.proton.amqp.transport.Close;
@@ -1417,7 +1418,9 @@ public class TransportImpl extends EndpointImpl
             throw new IllegalStateException("Transport cannot accept frame: " + frame);
         }
 
-        log(INCOMING, frame);
+        int channel = frame.getChannel();
+        Binary payload = frame.getPayload();
+        log(INCOMING, channel, frame.getBody(), payload);
 
         ProtocolTracer tracer = _protocolTracer.get();
         if( tracer != null )
@@ -1712,19 +1715,30 @@ public class TransportImpl extends EndpointImpl
     static String INCOMING = "<-";
     static String OUTGOING = "->";
 
-    void log(String event, TransportFrame frame)
+    void log(final String event, final int channel, final FrameBody frameBody, final Binary payload)
     {
         if (isTraceFramesEnabled()) {
             StringBuilder msg = new StringBuilder();
             msg.append("[").append(System.identityHashCode(this)).append(":")
-                .append(frame.getChannel()).append("]");
-            msg.append(" ").append(event).append(" ").append(frame.getBody());
+               .append(channel).append("]");
+            msg.append(" ").append(event).append(" ").append(frameBody);
 
-            Binary bin = frame.getPayload();
-            if (bin != null) {
-                msg.append(" (").append(bin.getLength()).append(") ");
-                msg.append(StringUtils.toQuotedString(bin, TRACE_FRAME_PAYLOAD_LENGTH, true));
+            if (payload != null) {
+                msg.append(" (").append(payload.getLength()).append(") ");
+                msg.append(StringUtils.toQuotedString(payload, TRACE_FRAME_PAYLOAD_LENGTH, true));
             }
+            System.out.println(msg.toString());
+        }
+    }
+
+    void log(final String event, final SaslFrameBody frameBody)
+    {
+        if (isTraceFramesEnabled()) {
+            int channel = 0;
+            StringBuilder msg = new StringBuilder();
+            msg.append("[").append(System.identityHashCode(this)).append(":")
+               .append(channel).append("]");
+            msg.append(" ").append(event).append(" ").append(frameBody);
             System.out.println(msg.toString());
         }
     }

--- a/proton-j/src/test/java/org/apache/qpid/proton/engine/impl/FrameParserTest.java
+++ b/proton-j/src/test/java/org/apache/qpid/proton/engine/impl/FrameParserTest.java
@@ -309,7 +309,7 @@ public class FrameParserTest
                 return false;
             }
 
-            FrameBody actualFrame = transportFrame.getBody();
+            FrameBody actualFrame = (FrameBody) transportFrame.getBody();
 
             int _expectedChannel = _expectedTransportFrame.getChannel();
             FrameBody expectedFrame = _expectedTransportFrame.getBody();


### PR DESCRIPTION
This patch adds a SASL protocol trace that is controlled by the same mechanism as the main protocol trace.

Could you comment on the approach?  If it is acceptable, I'll add some tests.

One unsettled question in my mind ProtocolTracer:  at the moment, ProtocolTracer implementations don't receive SaslFrameBodies. I did as this would break ProtocolTracer impls (including QpidJMS's - which would ClassCastException).  I wondered using a default method ProtocolTracer#ignoreSaslFrameBody which would return true. Comments appreciated..