### PR TITLE
PROTON-1998: add SASL protocol trace logging (v2)

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/FrameWriter.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/FrameWriter.java
@@ -23,6 +23,7 @@ package org.apache.qpid.proton.engine.impl;
 import java.nio.ByteBuffer;
 
 import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.security.SaslFrameBody;
 import org.apache.qpid.proton.amqp.transport.EmptyFrame;
 import org.apache.qpid.proton.amqp.transport.FrameBody;
 import org.apache.qpid.proton.codec.EncoderImpl;
@@ -151,6 +152,7 @@ class FrameWriter {
     }
 
     private void logFrame(int channel, Object frameBody, ReadableBuffer payload, int payloadSize) {
+        ProtocolTracer tracer = transport.getProtocolTracer();
         if (frameType == AMQP_FRAME_TYPE) {
             ReadableBuffer originalPayload = null;
             if (payload != null) {
@@ -170,9 +172,14 @@ class FrameWriter {
 
             transport.log(TransportImpl.OUTGOING, frame);
 
-            ProtocolTracer tracer = transport.getProtocolTracer();
             if (tracer != null) {
                 tracer.sentFrame(frame);
+            }
+        } else {
+            SaslFrameBody body = (SaslFrameBody) frameBody;
+            transport.log(TransportImpl.OUTGOING, body);
+            if (tracer != null) {
+                tracer.sentSaslBody(body);
             }
         }
     }

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/ProtocolTracer.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/ProtocolTracer.java
@@ -20,6 +20,7 @@
  */
 package org.apache.qpid.proton.engine.impl;
 
+import org.apache.qpid.proton.amqp.security.SaslFrameBody;
 import org.apache.qpid.proton.framing.TransportFrame;
 
 /**
@@ -29,4 +30,6 @@ public interface ProtocolTracer
 {
     public void receivedFrame(TransportFrame transportFrame);
     public void sentFrame(TransportFrame transportFrame);
+    default void receivedSaslBody(SaslFrameBody saslFrameBody) {}
+    default void sentSaslBody(SaslFrameBody saslFrameBody) {}
 }

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/SaslImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/SaslImpl.java
@@ -317,6 +317,14 @@ public class SaslImpl implements Sasl, SaslFrameBody.SaslFrameBodyHandler<Void>,
     @Override
     public void handle(SaslFrameBody frameBody, Binary payload)
     {
+        _transport.log(TransportImpl.INCOMING, frameBody);
+
+        ProtocolTracer tracer = _transport.getProtocolTracer();
+        if( tracer != null )
+        {
+            tracer.receivedSaslBody(frameBody);
+        }
+
         frameBody.invoke(this, payload, null);
     }
 

--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/TransportImpl.java
@@ -30,6 +30,7 @@ import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.UnsignedInteger;
 import org.apache.qpid.proton.amqp.UnsignedShort;
+import org.apache.qpid.proton.amqp.security.SaslFrameBody;
 import org.apache.qpid.proton.amqp.transport.Attach;
 import org.apache.qpid.proton.amqp.transport.Begin;
 import org.apache.qpid.proton.amqp.transport.Close;
@@ -1715,18 +1716,27 @@ public class TransportImpl extends EndpointImpl
     void log(String event, TransportFrame frame)
     {
         if (isTraceFramesEnabled()) {
-            StringBuilder msg = new StringBuilder();
-            msg.append("[").append(System.identityHashCode(this)).append(":")
-                .append(frame.getChannel()).append("]");
-            msg.append(" ").append(event).append(" ").append(frame.getBody());
-
-            Binary bin = frame.getPayload();
-            if (bin != null) {
-                msg.append(" (").append(bin.getLength()).append(") ");
-                msg.append(StringUtils.toQuotedString(bin, TRACE_FRAME_PAYLOAD_LENGTH, true));
-            }
-            System.out.println(msg.toString());
+            outputMessage(event, frame.getChannel(), frame.getBody(), frame.getPayload());
         }
+    }
+
+    void log(final String event, final SaslFrameBody frameBody) {
+        if (isTraceFramesEnabled()) {
+            outputMessage(event, 0, frameBody, null);
+        }
+    }
+
+    private void outputMessage(String event, int channel, Object frameBody, Binary payload) {
+        StringBuilder msg = new StringBuilder();
+
+        msg.append("[").append(System.identityHashCode(this)).append(":").append(channel).append("] ");
+        msg.append(event).append(" ").append(frameBody);
+        if (payload != null) {
+            msg.append(" (").append(payload.getLength()).append(") ");
+            msg.append(StringUtils.toQuotedString(payload, TRACE_FRAME_PAYLOAD_LENGTH, true));
+        }
+
+        System.out.println(msg.toString());
     }
 
     boolean isFrameTracingEnabled()

--- a/proton-j/src/test/java/org/apache/qpid/proton/engine/impl/TransportImplTest.java
+++ b/proton-j/src/test/java/org/apache/qpid/proton/engine/impl/TransportImplTest.java
@@ -29,12 +29,15 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Random;
 
 import org.apache.qpid.proton.Proton;
@@ -75,6 +78,7 @@ import org.apache.qpid.proton.message.Message;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 public class TransportImplTest
@@ -3636,5 +3640,55 @@ public class TransportImplTest
         assertNotNull("Expected an ErrorCondition to be returned", transport.getCondition());
         assertEquals("Unexpected ErrorCondition returned", ConnectionError.FRAMING_ERROR, transport.getCondition().getCondition());
         assertEquals("Unexpected description returned", "connection aborted", transport.getCondition().getDescription());
+    }
+
+    @Test
+    public void testProtocolTracingLogsToTracer()
+    {
+        Connection connection = new ConnectionImpl();
+        List<TransportFrame> frames = new ArrayList<>();
+        _transport.setProtocolTracer(new ProtocolTracer()
+        {
+            @Override
+            public void receivedFrame(final TransportFrame transportFrame)
+            {
+                frames.add(transportFrame);
+            }
+
+            @Override
+            public void sentFrame(TransportFrame transportFrame) { }
+        });
+
+        assertTrue(_transport.isHandlingFrames());
+        _transport.bind(connection);
+
+        assertTrue(_transport.isHandlingFrames());
+        _transport.handleFrame(TRANSPORT_FRAME_OPEN);
+        assertTrue(_transport.isHandlingFrames());
+
+        assertEquals(1, frames.size());
+        TransportFrame transportFrame = frames.get(0);
+        assertTrue(transportFrame.getBody() instanceof Open);
+        assertEquals(CHANNEL_ID, transportFrame.getChannel());
+    }
+
+    @Test
+    public void testProtocolTracingLogsToSystem() {
+        Connection connection = new ConnectionImpl();
+        TransportImpl spy = spy(_transport);
+
+        assertTrue(spy.isHandlingFrames());
+        spy.bind(connection);
+
+        assertTrue(spy.isHandlingFrames());
+        spy.handleFrame(TRANSPORT_FRAME_OPEN);
+        assertTrue(spy.isHandlingFrames());
+
+        ArgumentCaptor<TransportFrame> frameCatcher = ArgumentCaptor.forClass(TransportFrame.class);
+        Mockito.verify(spy).log(eq(TransportImpl.INCOMING), frameCatcher.capture());
+
+        assertEquals(TRANSPORT_FRAME_OPEN.getChannel(), frameCatcher.getValue().getChannel());
+        assertTrue(frameCatcher.getValue().getBody() instanceof Open);
+        assertNull(frameCatcher.getValue().getPayload());
     }
 }


### PR DESCRIPTION
Based on #30 but with updates to minimise some of the changes, use a common method for writing the output, move the point of logging SASL frame to be consistent with non-SASL cases, and add a couple more tests.