### PR TITLE
PROTON-2037: Ensure array offset is moved forward correctly

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/CompositeReadableBuffer.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/CompositeReadableBuffer.java
@@ -148,6 +148,7 @@ public class CompositeReadableBuffer implements ReadableBuffer {
         byte result = 0;
 
         if (index == position) {
+            maybeMoveToNextArray();
             result = currentArray[currentOffset];
         } else if (index < position) {
             result = getBackwards(index);
@@ -213,6 +214,7 @@ public class CompositeReadableBuffer implements ReadableBuffer {
                      (int)(currentArray[currentOffset++] & 0xFF) << 16 |
                      (int)(currentArray[currentOffset++] & 0xFF) << 8 |
                      (int)(currentArray[currentOffset++] & 0xFF) << 0;
+            maybeMoveToNextArray();
         } else {
             for (int i = INT_BYTES - 1; i >= 0; --i) {
                 result |= (int)(currentArray[currentOffset++] & 0xFF) << (i * Byte.SIZE);
@@ -242,6 +244,7 @@ public class CompositeReadableBuffer implements ReadableBuffer {
                      (long)(currentArray[currentOffset++] & 0xFF) << 16 |
                      (long)(currentArray[currentOffset++] & 0xFF) << 8 |
                      (long)(currentArray[currentOffset++] & 0xFF) << 0;
+            maybeMoveToNextArray();
         } else {
             for (int i = LONG_BYTES - 1; i >= 0; --i) {
                 result |= (long)(currentArray[currentOffset++] & 0xFF) << (i * Byte.SIZE);

--- a/proton-j/src/test/java/org/apache/qpid/proton/codec/CompositeReadableBufferTest.java
+++ b/proton-j/src/test/java/org/apache/qpid/proton/codec/CompositeReadableBufferTest.java
@@ -26,13 +26,17 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.*;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.InvalidMarkException;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.qpid.proton.Proton;
+import org.apache.qpid.proton.message.impl.MessageImpl;
 import org.junit.Test;
 
 /**
@@ -3024,6 +3028,26 @@ public class CompositeReadableBufferTest {
             emptySlice.append(new byte[] { 10 });
             fail("Should not be allowed to append to empty slice, must throw IllegalStateException");
         } catch (IllegalStateException ise) {}
+    }
+
+    @Test
+    public void testPositionMovedOnArrayBounderies() {
+        CompositeReadableBuffer buf = new CompositeReadableBuffer();
+        byte[] d1 = new byte[] { 1, 2, 3, 4 };
+        byte[] d2 = new byte[] { 5, 6 };
+        byte[] d3 = new byte[] { 7, 8, 9, 10, 11, 12, 13, 14 };
+        byte[] d4 = new byte[] { 15 };
+        buf.append(d1);
+        buf.append(d2);
+        buf.append(d3);
+        buf.append(d4);
+
+        buf.getInt();
+        assertEquals(5, buf.get(4));
+        buf.get();
+        buf.get();
+        buf.getLong();
+        assertEquals(15, buf.get(14));
     }
 
     @Test


### PR DESCRIPTION
* Add test case exposing the sequence of events causing an ArrayIndexOutOfBoundsException
* Fix offset movement for getLong and getInt methods
* Add checking of offset to get(int index)