### PR TITLE
PROTON-2029 Add fix and test for extraneous disposition after settle

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/DeliveryImpl.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/engine/impl/DeliveryImpl.java
@@ -132,6 +132,10 @@ public class DeliveryImpl implements Delivery
     @Override
     public void disposition(final DeliveryState state)
     {
+        if (_settled) {
+            return;
+        }
+
         _deliveryState = state;
         if(!_remoteSettled)
         {


### PR DESCRIPTION
Adds tests for disposition change after settled and a check for settled
state to circumvent more transport work being added when the delivery
has already been tagged as settled.