### PR TITLE
PROTON-2158 Adding automatic module name entry.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
 
     <!-- Plugin versions -->
     <maven-bundle-plugin-version>4.1.0</maven-bundle-plugin-version>
+    <maven-jar-plugin-version>3.2.0</maven-jar-plugin-version>
     <jacoco-plugin-version>0.8.4</jacoco-plugin-version>
     <surefire.version>2.22.2</surefire.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,6 @@
 
     <!-- Plugin versions -->
     <maven-bundle-plugin-version>4.1.0</maven-bundle-plugin-version>
-    <maven-jar-plugin-version>3.2.0</maven-jar-plugin-version>
     <jacoco-plugin-version>0.8.4</jacoco-plugin-version>
     <surefire.version>2.22.2</surefire.version>
 

--- a/proton-j/pom.xml
+++ b/proton-j/pom.xml
@@ -61,6 +61,18 @@
           </instructions>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven-jar-plugin-version}</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>org.apache.qpid.proton.j</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/proton-j/pom.xml
+++ b/proton-j/pom.xml
@@ -64,7 +64,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>${maven-jar-plugin-version}</version>
         <configuration>
           <archive>
             <manifestEntries>


### PR DESCRIPTION
* Adds an Automatic-Module-Name to the MANIFEST.MF so it can be consumed by JDK 9+ libraries without warnings.
  * Item added in manifest: `Automatic-Module-Name: org.apache.qpid.proton-j`
  * The module name was chosen by looking at the value of "Bundle-SymbolicName".
* Fixes issue: https://issues.apache.org/jira/browse/PROTON-2158
