### PR TITLE
PROTON-2437 fixed decoding of label for ARRAY8

### DIFF
--- a/proton-j/src/main/java/org/apache/qpid/proton/codec/EncodingCodes.java
+++ b/proton-j/src/main/java/org/apache/qpid/proton/codec/EncodingCodes.java
@@ -166,7 +166,7 @@ public interface EncodingCodes
             case MAP32:
                 return "MAP32:0xd1";
             case ARRAY8:
-                return "ARRAY32:0xe0";
+                return "ARRAY8:0xe0";
             case ARRAY32:
                 return "ARRAY32:0xf0";
             default:


### PR DESCRIPTION
when decoding the type code for ARRAY8/0xe0, the wrong label "ARRAY32:0xe0" was displayed.
thus ARRAY8/0xe0 and ARRAY32/0xf0 showed the same label, although the numeric part of the label was still correct.
this PR fixes the text part of the label.